### PR TITLE
Fix TypeScript type compatibility error in users.service

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -80,7 +80,7 @@ export class UsersService {
 
   async findAll(): Promise<Omit<User, 'passwordHash' | '__v' | '_id'>[]> {
     const users = await this.userModel.find().lean();
-    return users.map(({ passwordHash, __v, _id, ...rest }) => rest);
+    return users.map(({ passwordHash, __v, _id, ...rest }) => rest) as Omit<User, 'passwordHash' | '__v' | '_id'>[];
   }
 
   async findMe(
@@ -90,6 +90,6 @@ export class UsersService {
     if (!user) return null;
 
     const { passwordHash, __v, _id, ...rest } = user;
-    return rest;
+    return rest as Omit<User, 'passwordHash' | '__v' | '_id'>;
   }
 }


### PR DESCRIPTION
- Add explicit type assertions for lean() query results
- Resolve Mongoose FlattenMaps type compatibility issues
- Fixes build errors with TypeScript 5.7.3 and Mongoose 8.16.3
- 
## Summary
Fixes TypeScript compilation error in backend service that prevented Docker build.

## Changes
- Added type casting to resolve type incompatibility when using `.lean()` with Mongoose models
- Fixed return type mismatch in `findAll()` and `findMe()` methods

## Issue
The build was failing with TypeScript error TS2322 due to type incompatibility between 
`FlattenMaps<Db>` and the expected `Omit<User, ...>` return type when using Mongoose 8.16.3 
with TypeScript 5.7.3.

## Testing
- Backend builds successfully with `npm run build`
- Docker compose builds and runs without errors